### PR TITLE
Removal of master-slave vocabulary

### DIFF
--- a/ipcheck/opt/ipcheck.py
+++ b/ipcheck/opt/ipcheck.py
@@ -2227,7 +2227,7 @@ def _main(argv):
 "is-a-chef.org",
 "is-a-conservative.com",
 "is-a-cpa.com",
-"is-a-cubicle-slave.com",
+"is-a-cubicle-subordinate.com",
 "is-a-democrat.com",
 "is-a-designer.com",
 "is-a-doctor.com",


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.